### PR TITLE
Added preforking all workers in pool

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -144,7 +144,6 @@ function start(params, routes) {
     this.worker.module = 'qewd.worker';
     //this.worker.loaderFilePath = 'node_modules/ewd-xpress/node_modules/ewd_qoper8-worker.js';
     this.setWorkerPoolSize(config.poolSize);
-    this.setWorkerPoolPrefork(config.poolPrefork);
     this.setWorkerIdleLimit(config.idleLimit);
     
     if (params.database && params.resilientMode) {
@@ -200,51 +199,85 @@ function start(params, routes) {
     var io;
     var server;
 
-    if (!config.ssl) {
-      server = app.listen(config.port);
+    function startServer() {
+      if (!config.ssl) {
+        server = app.listen(config.port);
+      }
+      else {
+        var https = require('https');
+        //console.log('cwd: ' + process.cwd());
+        var options = {
+          key: fs.readFileSync(config.ssl.keyFilePath),
+          cert: fs.readFileSync(config.ssl.certFilePath)
+        };
+        server = https.createServer(options, app).listen(config.port);
+      }
+      if (!config.no_sockets) {
+  
+        // currently only socket.io supported for WebSockets
+  
+        if (!config.webSockets.module) config.webSockets.module = 'socket.io';
+        if (config.webSockets.module === 'socket.io') {
+          if (!config.webSockets.engine) {
+            io = require('socket.io')(server, {wsEngine: 'ws'});
+          }
+          else {
+            var engine = config.webSockets.engine;
+            if (engine !== 'ws' && engine !== 'uws') engine = 'ws';
+            io = require('socket.io')(server, {wsEngine: engine});
+          }
+        }
+      }
+  
+      // load QEWD socket handling logic
+      if (io) sockets(q, io, config.customSocketModule);
+  
+      console.log('========================================================');
+      console.log('QEWD.js is listening on port ' + config.port);
+      console.log('========================================================');
+  
+      q.on('response', function(messageObj) {
+        // handle intermediate messages from worker (which hasn't finished)
+        if (messageObj.socketId) {
+          //console.log('*** master on response sending message to ' + messageObj.socketId);
+          var id = messageObj.socketId;
+          delete messageObj.socketId;
+          delete messageObj.finished;
+          io.to(id).emit('ewdjs', messageObj);
+        }
+      });
+    }
+
+    if (config.poolPrefork) {
+      var workersStarted = 0;
+      q.on('workerStarted', function(workerPid, customQueue) {
+        var worker = q.worker.process[workerPid];
+        // put worker on hold until server is started (resilientmode)
+        // this requires that "workerProcessStarted" event is emitted synchronously after setting worker.isAvailable = true; in ewd-qoper8 startWorker
+        // so we set worker immediately unavailable again here until all workers and the server have started
+        if (worker) { worker.isAvailable = false; }
+        workersStarted++;
+        if (workersStarted === q.worker.poolSize) {
+          // start server
+          startServer();
+          // now set all workers available
+          for (var pid in q.worker.process) {
+            worker = q.worker.process[pid];
+            worker.isAvailable = true;
+          }
+          // start processing the queue immediately
+          if (customQueue || q.queue.length > 0) q.processQueue(customQueue);
+        }
+      });
+      // prefork all child processes in worker pool
+      for (var i = 0; i < q.worker.poolSize; i++) {
+        q.startWorker();
+      }  
     }
     else {
-      var https = require('https');
-      //console.log('cwd: ' + process.cwd());
-      var options = {
-        key: fs.readFileSync(config.ssl.keyFilePath),
-        cert: fs.readFileSync(config.ssl.certFilePath)
-      };
-      server = https.createServer(options, app).listen(config.port);
+      startServer();
     }
-    if (!config.no_sockets) {
-
-      // currently only socket.io supported for WebSockets
-
-      if (!config.webSockets.module) config.webSockets.module = 'socket.io';
-      if (config.webSockets.module === 'socket.io') {
-        if (!config.webSockets.engine) {
-          io = require('socket.io')(server, {wsEngine: 'ws'});
-        }
-        else {
-          var engine = config.webSockets.engine;
-          if (engine !== 'ws' && engine !== 'uws') engine = 'ws';
-          io = require('socket.io')(server, {wsEngine: engine});
-        }
-      }
-    }
-
-    // load QEWD socket handling logic
-    if (io) sockets(q, io, config.customSocketModule);
-
-    console.log('QEWD.js is listening on port ' + config.port);
-    console.log('========================================================');
-
-    q.on('response', function(messageObj) {
-      // handle intermediate messages from worker (which hasn't finished)
-      if (messageObj.socketId) {
-        //console.log('*** master on response sending message to ' + messageObj.socketId);
-        var id = messageObj.socketId;
-        delete messageObj.socketId;
-        delete messageObj.finished;
-        io.to(id).emit('ewdjs', messageObj);
-      }
-    });
+        
   });
 
   //if (!q.u_services) q.start();

--- a/lib/master.js
+++ b/lib/master.js
@@ -93,6 +93,8 @@ function start(params, routes) {
     serverName: params.serverName || 'qewd',
     port: params.port || 8080,
     poolSize: params.poolSize || 1,
+    poolPrefork: params.poolPrefork || false,
+    idleLimit: params.idleLimit || 3600000,
     webServer: params.webServer || 'express',
     webServerRootPath: params.webServerRootPath || process.cwd() + '/www/',
     no_sockets: params.no_sockets || false,
@@ -142,7 +144,9 @@ function start(params, routes) {
     this.worker.module = 'qewd.worker';
     //this.worker.loaderFilePath = 'node_modules/ewd-xpress/node_modules/ewd_qoper8-worker.js';
     this.setWorkerPoolSize(config.poolSize);
-	
+    this.setWorkerPoolPrefork(config.poolPrefork);
+    this.setWorkerIdleLimit(config.idleLimit);
+    
     if (params.database && params.resilientMode) {
       // connect master process to database 
       //  it will use asynch connections to save a copy of


### PR DESCRIPTION
- added a startServer() function in q.on('started')
- added preforking of all workers in pool in q.on('started')

If resilientMode is enabled and preforking is enabled too, all workers are put on hold initially until server is started.

In ewd-qoper8 startWorker(), when a new worker is set available on receiving the "workerProcessStarted" response, the code must stay synchronous until "workerStarted" event has been emitted - to make sure a new worker can't start processing queued messages before the QEWD server & sockets are up & running.