### PR TITLE
Debian + YottaDB support

### DIFF
--- a/installers/install_gtm.sh
+++ b/installers/install_gtm.sh
@@ -14,7 +14,7 @@ echo 'Preparing environment'
 
 sudo apt-get update
 sudo apt-get install -y build-essential libssl-dev
-sudo apt-get install -y wget gzip openssh-server curl python-minimal
+sudo apt-get install -y wget gzip openssh-server curl python-minimal libelf1
 
 # GT.M
 

--- a/installers/install_gtm_only.sh
+++ b/installers/install_gtm_only.sh
@@ -20,7 +20,7 @@ else
 
   sudo apt-get update
   sudo apt-get install -y build-essential libssl-dev
-  sudo apt-get install -y wget gzip openssh-server curl python-minimal
+  sudo apt-get install -y wget gzip openssh-server curl python-minimal libelf1
 
   # GT.M
 

--- a/installers/install_yottadb.sh
+++ b/installers/install_yottadb.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+
+# run using: source install_gtm.sh
+
+# Acknowledgement: Wladimir Mutel for NodeM configuration logic
+#                  KS Bhaskar for YottaDB installation logic
+
+# run as normal user, eg ubuntu
+
+
+# Prepare
+
+echo 'Preparing environment'
+
+sudo apt-get update
+sudo apt-get install -y build-essential libssl-dev
+sudo apt-get install -y wget gzip openssh-server curl python-minimal libelf1
+
+# YottaDB
+
+echo 'Installing YottaDB'
+
+mkdir /tmp/tmp # Create a temporary directory for the installer
+cd /tmp/tmp    # and change to it. Next command is to download the YottaDB installer
+wget https://raw.githubusercontent.com/YottaDB/YottaDB/d79a03daa49fdaf9b69200efdc95be98c8560133/sr_unix/gtminstall.sh -O gtminstall
+chmod +x gtminstall # Make the file executable
+
+# Thanks to KS Bhaskar for the following enhancement:
+
+##sudo -E ./gtminstall --utf8 default --verbose # download and install YottaDB including UTF-8 mode
+
+gtmroot=/usr/lib/yottadb
+gtmcurrent=$gtmroot/current
+if [ -e "$gtmcurrent"] ; then
+  mv -v $gtmcurrent $gtmroot/previous_`date -u +%Y-%m-%d:%H:%M:%S`
+fi
+sudo mkdir -p $gtmcurrent # make sure directory exists for links to current YottaDB
+sudo -E ./gtminstall --utf8 default --verbose --linkenv $gtmcurrent --linkexec $gtmcurrent # download and install YottaDB including UTF-8 mode
+
+
+echo 'Configuring YottaDB'
+
+# source "/usr/lib/fis-gtm/V6.3-000_x86_64"/gtmprofile
+# echo 'source "/usr/lib/fis-gtm/V6.3-000_x86_64"/gtmprofile' >> ~/.profile
+
+gtmprof=$gtmcurrent/gtmprofile
+gtmprofcmd="source $gtmprof"
+$gtmprofcmd
+tmpfile=`mktemp`
+if [ `grep -v "$gtmprofcmd" ~/.profile | grep $gtmroot >$tmpfile`] ; then
+  echo "Warning: existing commands referencing $gtmroot in ~/.profile may interfere with setting up environment"
+  cat $tmpfile
+fi
+
+# ****** Temporary fix to ensure that invocation of gtmprofile is added correctly to .profile
+
+# if [ `grep -v "$gtmprofcmd" ~/.profile` ] ; then echo "$gtmprofcmd" >> ~/.profile ; fi
+
+echo 'copying ' $gtmprofcmd ' to profile...'
+echo $gtmprofcmd >> ~/.profile
+
+# ****** end of temporary fix
+
+rm $tmpfile
+unset tmpfile gtmprofcmd gtmprof gtmcurrent gtmroot
+
+echo 'YottaDB has been installed and configured, ready for use'
+echo 'Enter the YottaDB shell by typing the command: gtm  Exit it by typing the command H'
+
+# --- End of KS Bhaskar enhancement
+
+# Node.js
+
+echo 'Installing Node.js'
+
+cd ~
+
+curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.32.1/install.sh | bash
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+nvm install 6
+
+#make Node.js available to sudo
+
+sudo ln -s /usr/local/bin/node /usr/bin/node
+sudo ln -s /usr/local/lib/node /usr/lib/node
+sudo ln -s /usr/local/bin/npm /usr/bin/npm
+sudo ln -s /usr/local/bin/node-waf /usr/bin/node-waf
+n=$(which node);n=${n%/bin/node}; chmod -R 755 $n/bin/*; sudo cp -r $n/{bin,lib,share} /usr/local
+
+# QEWD
+
+echo 'Installing QEWD and associated modules'
+
+cd ~
+mkdir qewd
+cd qewd
+npm install qewd qewd-monitor
+
+# NodeM
+
+echo 'Installing NodeM'
+
+npm install nodem
+sudo ln -sf $gtm_dist/libgtmshr.so /usr/local/lib/
+sudo ldconfig
+base=~/qewd
+[ -f "$GTMCI" ] || export GTMCI="$(find $base -iname nodem.ci)"
+nodemgtmr="$(find $base -iname v4wnode.m | tail -n1 | xargs dirname)"
+echo "$gtmroutines" | fgrep "$nodemgtmr" || export gtmroutines="$nodemgtmr $gtmroutines"
+
+echo 'base=~/qewd' >> ~/.profile
+echo '[ -f "$GTMCI" ] || export GTMCI="$(find $base -iname nodem.ci)"' >> ~/.profile
+echo 'nodemgtmr="$(find $base -iname v4wnode.m | tail -n1 | xargs dirname)"' >> ~/.profile
+echo 'echo "$gtmroutines" | fgrep "$nodemgtmr" || export gtmroutines="$nodemgtmr $gtmroutines"' >> ~/.profile
+
+# QEWD configuration
+
+echo 'Moving QEWD files into place'
+
+mv ~/qewd/node_modules/qewd/example/qewd-gtm.js ~/qewd/qewd.js
+
+cd ~/qewd
+mkdir www
+cd www
+mkdir qewd-monitor
+cp ~/qewd/node_modules/qewd-monitor/www/bundle.js ~/qewd/www/qewd-monitor
+cp ~/qewd/node_modules/qewd-monitor/www/*.html ~/qewd/www/qewd-monitor
+cp ~/qewd/node_modules/qewd-monitor/www/*.css ~/qewd/www/qewd-monitor
+
+cd ~/qewd
+
+echo 'Done!'
+echo 'You should now be able to start QEWD by typing: node qewd'


### PR DESCRIPTION
I made a tiny change to the GT.M install scripts to install libelf as debian doesn't have that installed by default.

YottaDB script done as well.

Both GT.M and YottaDB scripts were tested on VM images on KVM for:
 
 * Ubuntu 16.04
 * Debian 9.2
 * Debian 8.9