### PR TITLE
Use socket.io namespaces for proxy setups

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -253,7 +253,17 @@ function start(params, routes) {
       }
   
       // load QEWD socket handling logic
-      if (io) sockets(q, io, config.customSocketModule);
+      if (io) {
+        sockets(q, io, config.customSocketModule);
+        if (Array.isArray(config.webSockets.io_paths)) {
+          config.webSockets.io_paths.forEach(function(nsp) {
+            if (typeof nsp === 'string' && nsp.startsWith('/')) {
+              let io_nsp = io.of(nsp);
+              sockets(q, io_nsp, config.customSocketModule);
+            }
+          });
+        }
+      }
   
       console.log('========================================================');
       console.log('QEWD.js is listening on port ' + config.port);

--- a/up/run.js
+++ b/up/run.js
@@ -468,6 +468,7 @@ function setup(isDocker, service_name, isNative) {
     serverName: '=> either(qewd.serverName, "QEWD Server")',
     port: '=> either(qewd.port, 8080)',
     poolSize: '=> either(qewd.poolSize, 2)',
+    poolPrefork: '=> either(qewd.poolPrefork, false)',
     database: {
       type: '=> either(qewd.database.type, default_db)',
       params: '=> either(qewd.database.params, "<!delete>")',
@@ -475,6 +476,7 @@ function setup(isDocker, service_name, isNative) {
     webServer: '{<qewd.webServer>}',
     ssl: '{<qewd.ssl>}',
     webServerRootPath: webServerRootPath,
+    webSockets: '{<qewd.webSockets>}',
     cors: '=> either(qewd.cors, true)',
     bodyParser: '=> getBodyParser(qewd.bodyParser)',
     mode: '=> either(qewd.mode, "production")',


### PR DESCRIPTION
for QEWD.js servers behind a proxy, use of namespaces feature is needed to let the websocket work correctly
namespace feature in socket.io interferes with proxied url with subpath (subpath is seen by the socket.io client as a namespace)