### PR TITLE
fix: new error message added in Node.js v15.0.0

### DIFF
--- a/lib/jwtHandler.js
+++ b/lib/jwtHandler.js
@@ -42,6 +42,7 @@ function sizes(cipher) {
       return [nkey, niv];
     } catch (e) {
       if (/invalid iv length/i.test(e.message)) niv += 1;
+      else if (/invalid initialization vector/i.test(e.message)) niv += 1;
       else if (/invalid key length/i.test(e.message)) nkey += 1;
       else throw e;
     }

--- a/up/run.js
+++ b/up/run.js
@@ -469,6 +469,7 @@ function setup(isDocker, service_name, isNative) {
     port: '=> either(qewd.port, 8080)',
     poolSize: '=> either(qewd.poolSize, 2)',
     poolPrefork: '=> either(qewd.poolPrefork, false)',
+    idleLimit: '=> either(qewd.idleLimit, 3600000)',
     database: {
       type: '=> either(qewd.database.type, default_db)',
       params: '=> either(qewd.database.params, "<!delete>")',


### PR DESCRIPTION
Updated sizes() because it throws a new ERR_CRYPTO_INVALID_IV error introduced in Node.js v15.0.0:

bytestokey.js:29
else throw e;
^

TypeError: Invalid initialization vector
←[90m at Cipheriv.createCipherBase (node:internal/crypto/cipher:116:19)←[39m
←[90m at Cipheriv.createCipherWithIV (node:internal/crypto/cipher:135:3)←[39m
←[90m at new Cipheriv (node:internal/crypto/cipher:243:3)←[39m
←[90m at createCipheriv (node:crypto:138:10)←[39m
at sizes (bytestokey.js:24:7)
at compute (bytestokey.js:35:21)
at Object. (bytestokey.js:62:21)
←[90m at Module._compile (node:internal/modules/cjs/loader:1105:14)←[39m
←[90m at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)←[39m
←[90m at Module.load (node:internal/modules/cjs/loader:981:32)←[39m {
code: ←[32m'ERR_CRYPTO_INVALID_IV'←[39m
}

See https://nodejs.org/api/errors.html#err_crypto_invalid_iv