### PR TITLE
Update run.js - added missing config initialSessionTimeout

### DIFF
--- a/up/run.js
+++ b/up/run.js
@@ -483,7 +483,8 @@ function setup(isDocker, service_name, isNative) {
     mode: '=> either(qewd.mode, "production")',
     max_queue_length: '{<qewd.max_queue_length>}',
     use_worker_threads: '{<qewd.use_worker_threads>}',
-    sessionDocumentName: '{<qewd.sessionDocumentName>}'
+    sessionDocumentName: '{<qewd.sessionDocumentName>}',
+    initialSessionTimeout: '{<qewd.initialSessionTimeout>}'
   };
 
   var config;


### PR DESCRIPTION
There's no other way to set this value in qewd, which means it's currently impossible to control session timeout in up. This fixes that.